### PR TITLE
Fix critical bug in zap.

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,11 @@ func main() {
 	router.Handler("GET", "/varz", ctxWrapper{context, VarsHandler})
 	router.HandlerFunc("GET", "/healthz", HealthHandler)
 
+	// https://github.com/julienschmidt/httprouter is having issues with
+	// wildcard handling. As a result, we have to register index handler
+	// as the fallback. Fix incoming.
+	router.NotFound = ctxWrapper{context, IndexHandler}
+
 	// TODO check for errors - addr in use, sudo issues, etc.
 	fmt.Printf("Launching %s on %s:%d\n", appName, *host, *port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", *host, *port), router))


### PR DESCRIPTION
As it turns out, there were some changes in the julienschmidt/httprouter
project that break certain assumptions made about wildcard handling.
Most likely, this is related to commit 6f3f391, and manifested in issues
183 and 172.

Zap unit tests did not catch this since we use a HTTP recorder rather
than the actual framework.

For now, adding a small hack that registers the index handler as the
notfound handler.