### PR TITLE
add json pretty prints for /healthz

### DIFF
--- a/web.go
+++ b/web.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/Jeffail/gabs"
+	"encoding/json"
 )
 
 type context struct {
@@ -79,6 +80,17 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 // VarsHandler responds to /varz request and prints config.
 func VarsHandler(c *context, w http.ResponseWriter, r *http.Request) (int, error) {
 	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, "Config: "+c.config.String())
+	io.WriteString(w, jsonPrettyPrint(c.config.String()))
 	return 200, nil
+}
+
+// https://stackoverflow.com/a/36544455/5117259
+func jsonPrettyPrint(in string) string {
+	var out bytes.Buffer
+	err := json.Indent(&out, []byte(in), "", "\t")
+	if err != nil {
+		return in
+	}
+	out.WriteString("\n")
+	return out.String()
 }

--- a/web.go
+++ b/web.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Jeffail/gabs"
 	"encoding/json"
+	"github.com/Jeffail/gabs"
 )
 
 type context struct {


### PR DESCRIPTION
The recommended way to debug zap is to hit the endpoint `/varz` to see what the config is parsed into. However, it's not very human readable. Added pretty formatting to the endpoint to make life easier for people.