### PR TITLE
Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,51 @@
+# References:
+#  - https://blog.questionable.services/article/build-go-binaries-travis-ci-github/
+#  - https://goreleaser.com/ci/
+
 language: go
 sudo: false
 
-go:
-  - "1.7"
-  - "1.8 " 
-  - "1.9"
-  - "1.10"
-  - "1.11"
-  - "tip"
+matrix:
+  include:
+    # "1.x" always refers to the latest Go version, inc. the patch release.
+    # e.g. "1.x" is 1.11 until 1.11.1 is available.
+    - go: 1.x
+      env: LATEST=true
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: 1.10.x
+    - go: 1.11.x
+    - go: tip
+  allow_failures:
+    - go: tip
 
+# https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
 os:
   - linux
   - osx
   
 install:
-  - go get -t ./...
+  - go get -t -v ./...
 
-script: 
+# Only clone the most recent commit.
+git:
+  depth: 1
+
+
+script:
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go vet $(go list ./... | grep -v /vendor/)
   - go test -short -v ./...
   - go build -v ./...
   - ./e2e.sh
 
-after_success: |
-  test "$TRAVIS_OS_NAME" = "linux" -a -n "$TRAVIS_TAG" \
-  && go get github.com/goreleaser/goreleaser \
-  && goreleaser
+# calls goreleaser
+# https://docs.travis-ci.com/user/deployment
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux && $LATEST = true


### PR DESCRIPTION
- Set up goreleaser in the deploy block to fix the releases
- Better matrix on golang, with allowed failures on tip
- Added gofmt requirements to the test.