### PR TITLE
Add wildcard passthrough

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,4 @@ go test ./... -v
 
 - [Ivan Smirnov](http://ivansmirnov.name)
 - [Sergey Smirnov](https://smirnov.nyc/)
+- [Chris Egerton](https://github.com/C0urante)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Open up `c.yml` and update the mappings you would like. You can nest arbitrarily
 - `query` - acts almost like the `expand` option, but drops the separating slash between query expansion and search term (`example.com?q=foo` instead of `example.com?q=/foo`).
 - `port` - only valid as the first child under a host. Takes an int and appends it as `:$INT` to the host defined. See the usage in the [sample config](c.yml)
 
+Additionally, you can use `"*"` to capture a path element that should be retained as-is while also allowing for expansion of later elements to take place.
+
 Important gotcha: yaml has [reserved types](http://yaml.org/type/bool.html) and thus `n`, `y`, `no` and the like need to be quoted. See the sample config.
 
 When you add a new shortcut, you need to indicate to your web browser that it's not a search term. You can do this by typing it in once with just a slash. For example, if you add a shortcut `g/z` -> `github.com/issmirnov/zap`, if you try `g/z` right away you will get taken to the search page. Instead, try `g/` once, and then `g/z`. This initial step only needs to be taken once per new shortcut.
@@ -159,6 +161,15 @@ l:
     port: 8080
   "n":
     port: 9001
+ak:
+  expand: kafka.apache.org
+    hi:
+      expand: contact
+    "*":
+      j:
+        expand: javadoc/index.html?overview-summary.html
+      d:
+        expand: documentation.html
 ```
 
 With this config, you can use the following queries:
@@ -167,6 +178,8 @@ With this config, you can use the following queries:
   - `f/zuck` -> facebook.com/zuck
   - `f/php` -> facebook.com/groups/2204685680/
   - `r/catsstandingup` -> reddit.com/r/catsstandingup
+  - `ak/hi` -> kafka.apache.org/contact
+  - `ak/23/j` -> kafka.apache.org/23/javadoc/index.html?overview-summary.html
 
 ### Troubleshooting
 
@@ -242,3 +255,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 ## Contributors
 
 - [Ivan Smirnov](http://ivansmirnov.name)
+- [Chris Egerton](https://github.com/C0urante)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You'll notice the difference is that we have to run as `root` in order to bind t
 
 The config file is located at `/usr/local/etc/zap/c.yml` on OSX. For ubuntu, you will have to create `/etc/zap/c.yml` by hand.
 
-Open up `c.yml` and update the mappings you would like. You can nest arbitrarily deep. Expansions work on strings and ints. Notice that we have three keywords available: `expand`, `query`, and `port`.
+Open up `c.yml` and update the mappings you would like. You can nest arbitrarily deep. Expansions work on strings and ints. Notice that we have three reserved keywords available: `expand`, `query`, and `port`.
 
 - `expand` - takes a short token and expands it to the specified string. Turns `z` into `zap/`,
 - `query` - acts almost like the `expand` option, but drops the separating slash between query expansion and search term (`example.com?q=foo` instead of `example.com?q=/foo`).

--- a/config.go
+++ b/config.go
@@ -82,9 +82,7 @@ func validateConfig(c *gabs.Container) error {
 			if _, ok := v.Data().(float64); !ok {
 				errors = multierror.Append(errors, fmt.Errorf("expected float64 value for %T, got: %v", k, v.Data()))
 			}
-		case
-		    "ssl_off",
-		    "pass":
+		case "ssl_off":
 			// check that v is a boolean, else return error.
 			if _, ok := v.Data().(bool); !ok {
 				errors = multierror.Append(errors, fmt.Errorf("expected bool value for %T, got: %v", k, v.Data()))

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ const (
 	expandKey   = "expand"
 	queryKey    = "query"
 	portKey     = "port"
+	passKey     = "*"
 	sslKey      = "ssl_off"
 	httpsPrefix = "https:/" // second slash appended in expandPath() call
 	httpPrefix  = "http:/"  // second slash appended in expandPath() call
@@ -81,7 +82,9 @@ func validateConfig(c *gabs.Container) error {
 			if _, ok := v.Data().(float64); !ok {
 				errors = multierror.Append(errors, fmt.Errorf("expected float64 value for %T, got: %v", k, v.Data()))
 			}
-		case "ssl_off":
+		case
+		    "ssl_off",
+		    "pass":
 			// check that v is a boolean, else return error.
 			if _, ok := v.Data().(bool); !ok {
 				errors = multierror.Append(errors, fmt.Errorf("expected bool value for %T, got: %v", k, v.Data()))

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,22 @@ l:
     port: 8080
     s:
       expand: service
+ak:
+  expand: kafka.apache.org
+  hi:
+    expand: contact
+  "*":
+    d:
+      expand: documentation.html
+    j:
+      expand: javadoc/index.html?overview-summary.html
+wc:
+  expand: wildcard.com
+  "*":
+    "*":
+      "*":
+        four:
+          expand: "4"
 `
 
 func loadTestYaml() (*gabs.Container, error) {

--- a/text.go
+++ b/text.go
@@ -101,10 +101,10 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 		expandPath(child, token.Next(), res)
 		return
 	} else if child, pass := children[passKey]; pass {
-	    res.WriteString("/")
-	    res.WriteString(token.Value.(string))
-	    expandPath(child, token.Next(), res)
-	    return
+		res.WriteString("/")
+		res.WriteString(token.Value.(string))
+		expandPath(child, token.Next(), res)
+		return
 	}
 
 	// if tokens left over, append the rest

--- a/text.go
+++ b/text.go
@@ -72,7 +72,7 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 	}
 	children := c.ChildrenMap()
 	tokVal := token.Value.(string)
-	if child, ok := children[tokVal]; tokVal != passKey && ok {
+	if child, ok := children[tokVal]; !isReserved(tokVal) && ok {
 		p, action, err := getPrefix(child)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -100,7 +100,7 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 		}
 		expandPath(child, token.Next(), res)
 		return
-	} else if child, pass := children[passKey]; pass {
+	} else if child, ok := children[passKey]; ok {
 		res.WriteString("/")
 		res.WriteString(token.Value.(string))
 		expandPath(child, token.Next(), res)
@@ -111,5 +111,22 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 	for e := token; e != nil; e = e.Next() {
 		res.WriteString("/")
 		res.WriteString(e.Value.(string))
+	}
+}
+
+func isReserved(pathElem string) bool {
+	switch pathElem {
+	case expandKey:
+		return true
+	case queryKey:
+		return true
+	case portKey:
+		return true
+	case passKey:
+		return true
+	case sslKey:
+		return true
+	default:
+		return false
 	}
 }

--- a/text.go
+++ b/text.go
@@ -116,15 +116,12 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 
 func isReserved(pathElem string) bool {
 	switch pathElem {
-	case expandKey:
-		return true
-	case queryKey:
-		return true
-	case portKey:
-		return true
-	case passKey:
-		return true
-	case sslKey:
+	case
+		expandKey,
+		queryKey,
+		portKey,
+		passKey,
+		sslKey:
 		return true
 	default:
 		return false

--- a/text.go
+++ b/text.go
@@ -71,7 +71,8 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 		return
 	}
 	children := c.ChildrenMap()
-	if child, ok := children[token.Value.(string)]; ok {
+	tokVal := token.Value.(string)
+	if child, ok := children[tokVal]; tokVal != passKey && ok {
 		p, action, err := getPrefix(child)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/text.go
+++ b/text.go
@@ -42,6 +42,7 @@ func getPrefix(c *gabs.Container) (string, int, error) {
 		}
 		return "", 0, fmt.Errorf("unexpected type of expansion value, got %T instead of int or string", d)
 	}
+
 	q := c.Path(queryKey).Data()
 	if q != nil {
 		if s, ok := q.(string); ok {
@@ -70,8 +71,7 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 		return
 	}
 	children := c.ChildrenMap()
-	child, ok := children[token.Value.(string)]
-	if ok {
+	if child, ok := children[token.Value.(string)]; ok {
 		p, action, err := getPrefix(child)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -99,6 +99,11 @@ func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {
 		}
 		expandPath(child, token.Next(), res)
 		return
+	} else if child, pass := children[passKey]; pass {
+	    res.WriteString("/")
+	    res.WriteString(token.Value.(string))
+	    expandPath(child, token.Next(), res)
+	    return
 	}
 
 	// if tokens left over, append the rest

--- a/text_test.go
+++ b/text_test.go
@@ -138,75 +138,75 @@ func TestExpander(t *testing.T) {
 		})
 	})
 	Convey("Given 'wc/1/*/3/four'", t, func() {
-	    c, _ := loadTestYaml()
-	    l := tokenize("wc/1/*/3/four")
-	    var res bytes.Buffer
-	    res.WriteString(httpsPrefix)
+		c, _ := loadTestYaml()
+		l := tokenize("wc/1/*/3/four")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
 
-        expandPath(c, l.Front(), &res)
+		expandPath(c, l.Front(), &res)
 
-        Convey("result should equal 'https://wildcard.com/1/*/3/4'", func() {
-            So(res.String(), ShouldEqual, "https://wildcard.com/1/*/3/4")
-        })
+		Convey("result should equal 'https://wildcard.com/1/*/3/4'", func() {
+			So(res.String(), ShouldEqual, "https://wildcard.com/1/*/3/4")
+		})
 	})
 	Convey("Given 'wc/1/2/3/four'", t, func() {
-	    c, _ := loadTestYaml()
-	    l := tokenize("wc/1/2/3/four")
-	    var res bytes.Buffer
-	    res.WriteString(httpsPrefix)
+		c, _ := loadTestYaml()
+		l := tokenize("wc/1/2/3/four")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
 
-        expandPath(c, l.Front(), &res)
+		expandPath(c, l.Front(), &res)
 
-        Convey("result should equal 'https://wildcard.com/1/2/3/4'", func() {
-            So(res.String(), ShouldEqual, "https://wildcard.com/1/2/3/4")
-        })
+		Convey("result should equal 'https://wildcard.com/1/2/3/4'", func() {
+			So(res.String(), ShouldEqual, "https://wildcard.com/1/2/3/4")
+		})
 	})
 	Convey("Given 'ak/hi'", t, func() {
-	    c, _ := loadTestYaml()
-	    l := tokenize("ak/hi")
-	    var res bytes.Buffer
-	    res.WriteString(httpsPrefix)
+		c, _ := loadTestYaml()
+		l := tokenize("ak/hi")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
 
-        expandPath(c, l.Front(), &res)
+		expandPath(c, l.Front(), &res)
 
-        Convey("result should equal 'https://kafka.apache.org/contact", func() {
-            So(res.String(), ShouldEqual, "https://kafka.apache.org/contact")
-        })
+		Convey("result should equal 'https://kafka.apache.org/contact", func() {
+			So(res.String(), ShouldEqual, "https://kafka.apache.org/contact")
+		})
 	})
 	Convey("Given 'ak/23'", t, func() {
-	    c, _ := loadTestYaml()
-	    l := tokenize("ak/23")
-	    var res bytes.Buffer
-	    res.WriteString(httpsPrefix)
+		c, _ := loadTestYaml()
+		l := tokenize("ak/23")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
 
-        expandPath(c, l.Front(), &res)
+		expandPath(c, l.Front(), &res)
 
-        Convey("result should equal 'https://kafka.apache.org/23", func() {
-            So(res.String(), ShouldEqual, "https://kafka.apache.org/23")
-        })
+		Convey("result should equal 'https://kafka.apache.org/23", func() {
+			So(res.String(), ShouldEqual, "https://kafka.apache.org/23")
+		})
 	})
 	Convey("Given 'ak/23/j", t, func() {
-	    c, _ := loadTestYaml()
-	    l := tokenize("ak/23/j")
-	    var res bytes.Buffer
-	    res.WriteString(httpsPrefix)
+		c, _ := loadTestYaml()
+		l := tokenize("ak/23/j")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
 
-        expandPath(c, l.Front(), &res)
+		expandPath(c, l.Front(), &res)
 
-        Convey("result should equal 'https://kafka.apache.org/23/javadoc/index.html?overview-summary.html", func() {
-            So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
-        })
+		Convey("result should equal 'https://kafka.apache.org/23/javadoc/index.html?overview-summary.html", func() {
+			So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
+		})
 	})
-//	Convey("Given 'ak/expand/j'", t, func() {
-//	    c, _ := loadTestYaml()
-//	    l := tokenize("ak/expand/j")
-//	    var res bytes.Buffer
-//	    res.WriteString(httpsPrefix)
-//
-//        expandPath(c, l.Front(), &res)
-//
-//        Convey("result should equal 'https://kafka.apache.org/expand/j", func() {
-//            So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/j")
-//        })
-//	})
+	//	Convey("Given 'ak/expand/j'", t, func() {
+	//	    c, _ := loadTestYaml()
+	//	    l := tokenize("ak/expand/j")
+	//	    var res bytes.Buffer
+	//	    res.WriteString(httpsPrefix)
+	//
+	//        expandPath(c, l.Front(), &res)
+	//
+	//        Convey("result should equal 'https://kafka.apache.org/expand/j", func() {
+	//            So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/j")
+	//        })
+	//	})
 }

--- a/text_test.go
+++ b/text_test.go
@@ -137,6 +137,18 @@ func TestExpander(t *testing.T) {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foo/bar/baz/")
 		})
 	})
+	Convey("Given 'g/query/homebrew'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("g/query/homebrew")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		expandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://github.com/query/homebrew'", func() {
+			So(res.String(), ShouldEqual, "https://github.com/query/homebrew")
+		})
+	})
 	Convey("Given 'wc/1/*/3/four'", t, func() {
 		c, _ := loadTestYaml()
 		l := tokenize("wc/1/*/3/four")
@@ -197,16 +209,16 @@ func TestExpander(t *testing.T) {
 			So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
 		})
 	})
-	//	Convey("Given 'ak/expand/j'", t, func() {
-	//	    c, _ := loadTestYaml()
-	//	    l := tokenize("ak/expand/j")
-	//	    var res bytes.Buffer
-	//	    res.WriteString(httpsPrefix)
-	//
-	//        expandPath(c, l.Front(), &res)
-	//
-	//        Convey("result should equal 'https://kafka.apache.org/expand/j", func() {
-	//            So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/j")
-	//        })
-	//	})
+	Convey("Given 'ak/expand/j'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("ak/expand/j")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		expandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://kafka.apache.org/expand/javadoc/index.html?overview-summary.html", func() {
+			So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/javadoc/index.html?overview-summary.html")
+		})
+	})
 }

--- a/text_test.go
+++ b/text_test.go
@@ -137,4 +137,52 @@ func TestExpander(t *testing.T) {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foo/bar/baz/")
 		})
 	})
+	Convey("Given 'wc/1/2/3/four'", t, func() {
+	    c, _ := loadTestYaml()
+	    l := tokenize("wc/1/2/3/four")
+	    var res bytes.Buffer
+	    res.WriteString(httpsPrefix)
+
+        expandPath(c, l.Front(), &res)
+
+        Convey("result should equal 'https://wildcard.com/1/2/3/4'", func() {
+            So(res.String(), ShouldEqual, "https://wildcard.com/1/2/3/4")
+        })
+	})
+	Convey("Given 'ak/hi'", t, func() {
+	    c, _ := loadTestYaml()
+	    l := tokenize("ak/hi")
+	    var res bytes.Buffer
+	    res.WriteString(httpsPrefix)
+
+        expandPath(c, l.Front(), &res)
+
+        Convey("result should equal 'https://kafka.apache.org/contact", func() {
+            So(res.String(), ShouldEqual, "https://kafka.apache.org/contact")
+        })
+	})
+	Convey("Given 'ak/23'", t, func() {
+	    c, _ := loadTestYaml()
+	    l := tokenize("ak/23")
+	    var res bytes.Buffer
+	    res.WriteString(httpsPrefix)
+
+        expandPath(c, l.Front(), &res)
+
+        Convey("result should equal 'https://kafka.apache.org/23", func() {
+            So(res.String(), ShouldEqual, "https://kafka.apache.org/23")
+        })
+	})
+	Convey("Given 'ak/23/j", t, func() {
+	    c, _ := loadTestYaml()
+	    l := tokenize("ak/23/j")
+	    var res bytes.Buffer
+	    res.WriteString(httpsPrefix)
+
+        expandPath(c, l.Front(), &res)
+
+        Convey("result should equal 'https://kafka.apache.org/23/javadoc/index.html?overview-summary.html", func() {
+            So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
+        })
+	})
 }

--- a/text_test.go
+++ b/text_test.go
@@ -137,6 +137,18 @@ func TestExpander(t *testing.T) {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foo/bar/baz/")
 		})
 	})
+	Convey("Given 'wc/1/*/3/four'", t, func() {
+	    c, _ := loadTestYaml()
+	    l := tokenize("wc/1/*/3/four")
+	    var res bytes.Buffer
+	    res.WriteString(httpsPrefix)
+
+        expandPath(c, l.Front(), &res)
+
+        Convey("result should equal 'https://wildcard.com/1/*/3/4'", func() {
+            So(res.String(), ShouldEqual, "https://wildcard.com/1/*/3/4")
+        })
+	})
 	Convey("Given 'wc/1/2/3/four'", t, func() {
 	    c, _ := loadTestYaml()
 	    l := tokenize("wc/1/2/3/four")
@@ -185,4 +197,16 @@ func TestExpander(t *testing.T) {
             So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
         })
 	})
+//	Convey("Given 'ak/expand/j'", t, func() {
+//	    c, _ := loadTestYaml()
+//	    l := tokenize("ak/expand/j")
+//	    var res bytes.Buffer
+//	    res.WriteString(httpsPrefix)
+//
+//        expandPath(c, l.Front(), &res)
+//
+//        Convey("result should equal 'https://kafka.apache.org/expand/j", func() {
+//            So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/j")
+//        })
+//	})
 }


### PR DESCRIPTION
Most URL patterns behave nicely with Zap as-is, but there are a few exceptions. One gap I've encountered is with URLS that embed version numbers as path elements; for example, the [Apache Kafka docs](https://kafka.apache.org/10/documentation/) use the major and minor version number concatenated (with no dot delimiter) as their first path element and each version of their docs so far has followed the same pattern for where javadocs, quickstarts, configuration docs, etc. are found.
I've had to install several redundant redirects in my Zap config to work with this:
```yaml
ak:
  expand: kafka.apache.org
  "10":
    expand: "10"
    j:
      expand: javadoc/index.html?overview-summary.html
    d:
      expand: documentation.html
  "11":
    expand: "11"
    j:
      expand: javadoc/index.html?overview-summary.html
    d:
      expand: documentation.html
  # ...more of the same...
  "23":
    expand: "23"
    j:
      expand: javadoc/index.html?overview-summary.html
    d:
      expand: documentation.html
```
However, that's clearly a workaround and it'd be nice if Zap recognized URL patterns like this natively.
As a light first pass at addressing this issue, I'd like to propose that the special path of `"*"` be allowed to match any path element that isn't explicitly matched in the config file. Should this match occur, the path element will then be kept as-is, but also allow for expansion of the remaining path elements.
An example is included in the README, and a few tests are added that should also help demonstrate the intended functionality. To put things into context, the above config snippet could now be reduced to:
```yaml
ak:
  expand: kafka.apache.org
  "*":
    j:
      expand: javadoc/index.html?overview-summary.html
    d:
      expand: documentation.html
```