### PR TITLE
Clean up root directory to conform to standard go spec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 # compiled files
 zap
 
+# Include our actual code, which is excluded by the "zap" directive above.
+!/cmd/zap
+
 # Goland
 .idea/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ os:
 script:
   - diff -u <(echo -n) <(go fmt $(go list ./...))
   - go vet $(go list ./...)
-  - go test -short -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-  - go build -v ./...
+  - go test -short -v ./... -race -coverprofile=coverage.txt -covermode=atomic ./cmd
+  - go build -o zap -v ./cmd/
   - ./e2e.sh
 
 # calls goreleaser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Contributing to Zap
 
 Patches are welcome! Please use the standard GitHub workflow - fork this
-repo and submit a PR. I'll usually get to it within a few days.
+repo and submit a PR. I'll usually get to it within a few days. If I miss your PR email, feel free to ping me directly at isgsmirnov@gmail.com after about a week.
 
 ## Setting up dev environment
 
@@ -13,16 +13,16 @@ or your favorite web editor with Golang support.
 git clone $your_fork zap
 cd zap
 go get
-go build . # sanity check
+go build -o zap -v ./cmd/ # sanity check
 
 # install test deps and run all tests
-go test ./... -v 
+go test -short -v ./... -race -coverprofile=coverage.txt -covermode=atomic ./cmd 
 ./e2e.sh
 ```
 
 ## Handy commands for local development:
 
-- `go build && ./zap` to run locally
+- `go build -o zap -v ./cmd/ && ./zap` to run locally
 - `curl -I -L -H 'Host: g' localhost:8927/z` - to test locally e2e
 - `goconvey -excludedDirs dist` - launches web UI for go tests.
 - `./e2e.sh` runs CLI tests.

--- a/cmd/zap/config_test.go
+++ b/cmd/zap/config_test.go
@@ -1,4 +1,4 @@
-package main
+package zap
 
 import (
 	"testing"
@@ -120,8 +120,8 @@ func TestParseYaml(t *testing.T) {
 	Convey("Given a valid 'c.yml' file", t, func() {
 		Afero = &afero.Afero{Fs: afero.NewMemMapFs()}
 		Afero.WriteFile("c.yml", []byte(cYaml), 0644)
-		c, err := parseYaml("c.yml")
-		Convey("parseYaml should throw no error", func() {
+		c, err := ParseYaml("c.yml")
+		Convey("ParseYaml should throw no error", func() {
 			So(err, ShouldBeNil)
 		})
 		Convey("the gabs object should have path 'zz' present", func() {
@@ -131,33 +131,33 @@ func TestParseYaml(t *testing.T) {
 }
 
 func TestValidateConfig(t *testing.T) {
-	Convey("Given a correctly formatted yaml config", t, func() {
+	Convey("Given a correctly formatted yaml Config", t, func() {
 		conf, _ := parseYamlString(cYaml)
 		//fmt.Printf(err.Error())
 		Convey("The validator should pass", func() {
-			So(validateConfig(conf), ShouldBeNil)
+			So(ValidateConfig(conf), ShouldBeNil)
 		})
 	})
 
 	// The YAML libraries don't have support for detecting duplicate keys
 	// at parse time. Users will have to figure this out themselves.
-	//Convey("Given a yaml config with duplicated keys", t, func() {
+	//Convey("Given a yaml Config with duplicated keys", t, func() {
 	//	conf, _ := parseYamlString(duplicatedYAML)
 	//	Convey("The validator should complain", func() {
-	//		So(validateConfig(conf), ShouldNotBeNil)
+	//		So(ValidateConfig(conf), ShouldNotBeNil)
 	//	})
 	//})
 
-	Convey("Given a YAML config with unknown keys", t, func() {
+	Convey("Given a YAML Config with unknown keys", t, func() {
 		conf, _ := parseYamlString(badkeysYAML)
 		Convey("The validator should raise an error", func() {
-			So(validateConfig(conf), ShouldNotBeNil)
+			So(ValidateConfig(conf), ShouldNotBeNil)
 		})
 	})
 
-	Convey("Given a YAML config with malformed values", t, func() {
+	Convey("Given a YAML Config with malformed values", t, func() {
 		conf, _ := parseYamlString(badValuesYAML)
-		err := validateConfig(conf)
+		err := ValidateConfig(conf)
 		Convey("The validator should raise a ton of errors", func() {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "expected float64 value for string, got: not_int")

--- a/cmd/zap/structs.go
+++ b/cmd/zap/structs.go
@@ -1,0 +1,35 @@
+package zap
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/Jeffail/gabs/v2"
+)
+
+type Context struct {
+	// Json container with path configs
+	Config *gabs.Container
+
+	// Enables safe hot reloading of Config.
+	ConfigMtx sync.Mutex
+}
+
+type CtxWrapper struct {
+	*Context
+	H func(*Context, http.ResponseWriter, *http.Request) (int, error)
+}
+
+func (cw CtxWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	status, err := cw.H(cw.Context, w, r) // this runs the actual handler, defined in struct.
+	if err != nil {
+		switch status {
+		case http.StatusInternalServerError:
+			http.Error(w, fmt.Sprintf("HTTP %d: %q", status, err), status)
+			// TODO - add bad request?
+		default:
+			http.Error(w, err.Error(), status)
+		}
+	}
+}

--- a/cmd/zap/text.go
+++ b/cmd/zap/text.go
@@ -1,4 +1,4 @@
-package main
+package zap
 
 import (
 	"bytes"
@@ -59,11 +59,11 @@ func getPrefix(c *gabs.Container) (string, int, error) {
 		return "", 0, fmt.Errorf("casting port key to float64 failed for %T:%v", p, p)
 	}
 
-	return "", 0, fmt.Errorf("error in config, no key matching 'expand', 'query', 'port' or 'schema' in %s", c.String())
+	return "", 0, fmt.Errorf("error in Config, no key matching 'expand', 'query', 'port' or 'schema' in %s", c.String())
 }
 
-// expandPath takes a config, list of tokens (parsed from request) and the results buffer
-// At each level of recursion, it matches the token to the action described in the config, and writes it
+// expandPath takes a Config, list of tokens (parsed from request) and the results buffer
+// At each level of recursion, it matches the token to the action described in the Config, and writes it
 // to the result buffer. There is special care needed to handle slashes correctly, which makes this function
 // quite nontrivial. Tests are crucial to ensure correctness.
 func expandPath(c *gabs.Container, token *list.Element, res *bytes.Buffer) {

--- a/cmd/zap/text_test.go
+++ b/cmd/zap/text_test.go
@@ -1,4 +1,4 @@
-package main
+package zap
 
 import (
 	"bytes"


### PR DESCRIPTION
- There's no need to make separate packages for the zap internals, as it
  would be just a single file + test per package.
- We have to update the build commands to specify the cmd dir.