### PR TITLE
Add support for expansion of direct children of query keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ g:
     expand: issmirnov/dotfiles
   s:
     query: search?q=
+    ak:
+      expand: apache/kafka
   z:
     expand: issmirnov/zap
 r:

--- a/cmd/zap/config_test.go
+++ b/cmd/zap/config_test.go
@@ -72,6 +72,14 @@ g:
     expand: issmirnov/zap
   s:
     query: "search?q="
+    me:
+      expand: issmirnov
+      z:
+        expand: zap
+    ak:
+      query: apache/kafka
+      c:
+        query: +connect
 z:
   expand: zero.com
   ssl_off: yes

--- a/cmd/zap/text_test.go
+++ b/cmd/zap/text_test.go
@@ -47,7 +47,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/issmirnov/zap'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/issmirnov/zap")
@@ -59,7 +59,7 @@ func TestExpander(t *testing.T) {
 	//     var res bytes.Buffer
 	//     res.WriteString(httpsPrefix)
 	//
-	//     expandPath(c, l.Front(), &res)
+	//     ExpandPath(c, l.Front(), &res)
 	//
 	//     Convey("result should equal 'https://example.com/999'", func() {
 	//         So(res.String(), ShouldEqual, "https://example.com/999")
@@ -71,7 +71,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/issmirnov/zap/extratext'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/issmirnov/zap/extratext")
@@ -83,7 +83,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/")
@@ -95,7 +95,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/issmirnov/zap/very/deep/path'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/issmirnov/zap/very/deep/path")
@@ -107,7 +107,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/search?q=foobar'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foobar")
@@ -119,7 +119,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/search?q=foo/bar/baz'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foo/bar/baz")
@@ -131,7 +131,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/search?q=foo/bar/baz/'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=foo/bar/baz/")
@@ -143,7 +143,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://github.com/query/homebrew'", func() {
 			So(res.String(), ShouldEqual, "https://github.com/query/homebrew")
@@ -155,7 +155,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://wildcard.com/1/*/3/4'", func() {
 			So(res.String(), ShouldEqual, "https://wildcard.com/1/*/3/4")
@@ -167,7 +167,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://wildcard.com/1/2/3/4'", func() {
 			So(res.String(), ShouldEqual, "https://wildcard.com/1/2/3/4")
@@ -179,7 +179,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://kafka.apache.org/contact", func() {
 			So(res.String(), ShouldEqual, "https://kafka.apache.org/contact")
@@ -191,7 +191,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://kafka.apache.org/23", func() {
 			So(res.String(), ShouldEqual, "https://kafka.apache.org/23")
@@ -203,7 +203,7 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://kafka.apache.org/23/javadoc/index.html?overview-summary.html", func() {
 			So(res.String(), ShouldEqual, "https://kafka.apache.org/23/javadoc/index.html?overview-summary.html")
@@ -215,10 +215,58 @@ func TestExpander(t *testing.T) {
 		var res bytes.Buffer
 		res.WriteString(httpsPrefix)
 
-		expandPath(c, l.Front(), &res)
+		ExpandPath(c, l.Front(), &res)
 
 		Convey("result should equal 'https://kafka.apache.org/expand/javadoc/index.html?overview-summary.html", func() {
 			So(res.String(), ShouldEqual, "https://kafka.apache.org/expand/javadoc/index.html?overview-summary.html")
+		})
+	})
+	Convey("Given 'g/s/me'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("g/s/me")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		ExpandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://github.com/search?q=issmirnov'", func() {
+			So(res.String(), ShouldEqual, "https://github.com/search?q=issmirnov")
+		})
+	})
+	Convey("Given 'g/s/me.z'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("g/s/me/z")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		ExpandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://github.com/search?q=issmirnov/zap'", func() {
+			So(res.String(), ShouldEqual, "https://github.com/search?q=issmirnov/zap")
+		})
+	})
+	Convey("Given 'g/s/ak'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("g/s/ak")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		ExpandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://github.com/search?q=apache/kafka'", func() {
+			So(res.String(), ShouldEqual, "https://github.com/search?q=apache/kafka")
+		})
+	})
+	Convey("Given 'g/s/ak/c'", t, func() {
+		c, _ := loadTestYaml()
+		l := tokenize("g/s/ak/c")
+		var res bytes.Buffer
+		res.WriteString(httpsPrefix)
+
+		ExpandPath(c, l.Front(), &res)
+
+		Convey("result should equal 'https://github.com/search?q=apache/kafka+connect'", func() {
+			So(res.String(), ShouldEqual, "https://github.com/search?q=apache/kafka+connect")
 		})
 	})
 }

--- a/cmd/zap/text_test.go
+++ b/cmd/zap/text_test.go
@@ -233,7 +233,7 @@ func TestExpander(t *testing.T) {
 			So(res.String(), ShouldEqual, "https://github.com/search?q=issmirnov")
 		})
 	})
-	Convey("Given 'g/s/me.z'", t, func() {
+	Convey("Given 'g/s/me/z'", t, func() {
 		c, _ := loadTestYaml()
 		l := tokenize("g/s/me/z")
 		var res bytes.Buffer

--- a/cmd/zap/web.go
+++ b/cmd/zap/web.go
@@ -48,7 +48,7 @@ func IndexHandler(ctx *Context, w http.ResponseWriter, r *http.Request) (int, er
 		path.WriteString(httpsPrefix)
 	}
 
-	expandPath(conf, tokensStart, &path)
+	ExpandPath(conf, tokensStart, &path)
 
 	// send result
 	http.Redirect(w, r, path.String(), http.StatusFound)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945
 	github.com/spf13/afero v1.2.2
 	golang.org/x/exp/errors v0.0.0-20200901203048-c4f52b2c50aa
-	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
+	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
Hey Vania, hope things are well! Been using Zap consistently on all my machines for the last few years and for the most part it's been smooth and "just worked". One thing that's stuck out is the lack of support for expanding elements after a query, which would come in handy with things like Gerrit which expose an endpoint for viewing open PRs on a repo at `/q/project:<project>`. Right now I have to fully type out the project name, but with this change I can add shortcuts for those.

If merged as-is, this would technically be a breaking change. For example, with a config of:
```yaml
g:
  expand: github.com
  s:
    query: search?q=
    ak:
      expand: apache/kafka
```

the expansion for the URL `g/s/thing/ak` would go from `github.com/search?q=thing/apache/kafka` to  `github.com/search?q=thing/ak`, and for `g/s/ak`, would go from `github.com/search?q=ak` to `github.com/search?q=apache/kafka`.

I'd argue that since this is addressing a bug and it's unlikely that people are relying on the existing expansion behavior for keys underneath queries, it'd be fine to make this change. But if not, we can consider introducing a separate key type like `query2` (awful name, would need to change) that would enable this behavior while preserving the existing behavior for `query`, or adding a global flag to the config file or the CLI that enables/disables this new behavior.